### PR TITLE
Fix relative filename path and catch error

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -39,11 +39,14 @@ if (help || !file) {
   return;
 }
 
-const fileName = path.resolve(process.cwd(), file);
-WordlistToJSON(fileName, { value }).then( output => {
+const pathToFile = path.resolve(process.cwd(), file);
+const fileName = path.basename(pathToFile).split('.').slice(0, -1).join('.');
+
+WordlistToJSON(pathToFile, { value }).then( output => {
   fs.writeFileSync(
-    path.resolve(process.cwd(), `./${file.split('.')[0]}.json`),
+    path.resolve(process.cwd(), `${fileName}.json`),
     JSON.stringify(output, undefined, +space)
   );
-  console.log('File written!', chalk.cyan.bold(`./${file.split('.')[0]}.json`));
-});
+})
+.then(() => console.log('File has been written to:', chalk.cyan.bold(`${fileName}.json`)))
+.catch(error => console.error(error.message));


### PR DESCRIPTION
Running `wordlist-to-json --file "./filename.txt"` will cause the result file name to be `.json`.
This fix will use the actual filename instead of guessing from the path. The current implementation also doesn't cover case when filename is something like `foo.bar.baz.txt`, which will still output as `.json`

I also added error catcher for better error message output in the CLI.

@MrBenJ I only tried locally by doing `node cli.js --file ./file.txt`. Node noob here, so lmk if I can do it in a better way.

I would also be more than happy to update this PR if #6 will be merge in first and has any conflict.